### PR TITLE
Require menuinst v2 in conda-build

### DIFF
--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -79,3 +79,13 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: 23.9.0
+---
+# conda-build 3.28.x uses menuinst to validate v2 JSONs, but doesn't pin a lower
+# bound version; on Windows, menuinst 1.x is eligible, which breaks the import
+if:
+  name: conda-build
+  version_le: 3.28.1
+then:
+  - replace_depends:
+      old: menuinst
+      new: menuinst >=2.0.1

--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -85,6 +85,7 @@ then:
 if:
   name: conda-build
   version_le: 3.28.1
+  timestamp_le: 1702544267086  # 2023-12-14
 then:
   - replace_depends:
       old: menuinst


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
